### PR TITLE
[CHE-71] Deploy yandex cloud

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -18,16 +18,9 @@ services:
   server:
     container_name: cheburland-server
     image: dksr/cheburland:latest
-    build:
-      context: .
-      dockerfile: Dockerfile.server
-      args:
-        SERVER_PORT: 3000
     restart: always
-    env_file:
-      - .env
     ports:
-      - "3000:3000"
+      - "80:3000"
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,49 @@
+version: "3.9"
+
+services:
+  postgres:
+    container_name: cheburland-postgres
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    networks:
+      - cheburland
+  server:
+    container_name: cheburland-server
+    image: dksr/cheburland:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      args:
+        SERVER_PORT: 3000
+    restart: always
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+    depends_on:
+      - postgres
+    volumes:
+      - ./packages/server:/app/packages/server
+    networks:
+      - cheburland
+
+networks:
+  cheburland:
+    driver: bridge
+
+volumes:
+  pg-data:
+  pg-admin-data:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7311,7 +7311,7 @@ redux@^4.2.1:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-reflect-metadata@^0.1.13:
+reflect-metadata@0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
@@ -7531,14 +7531,14 @@ sequelize-pool@^7.1.0:
   resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-7.1.0.tgz#210b391af4002762f823188fd6ecfc7413020768"
   integrity sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==
 
-sequelize-typescript@^2.1.5:
+sequelize-typescript@2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/sequelize-typescript/-/sequelize-typescript-2.1.5.tgz#f12d14607cc8abfd6172cd99f7d3255ec5c4d78e"
   integrity sha512-x1CNODct8gJyfZPwEZBU5uVGNwgJI2Fda913ZxD5ZtCSRyTDPBTS/0uXciF+MlCpyqjpmoCAPtudQWzw579bzA==
   dependencies:
     glob "7.2.0"
 
-sequelize@^6.32.1:
+sequelize@6.32.1:
   version "6.32.1"
   resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.32.1.tgz#8e8669a8d6cf711d2d94b33cc721928fad7487f6"
   integrity sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==


### PR DESCRIPTION
Добавлен файл docker-compose.deploy.yml который используется на виртуальном сервере в яндекс клауд для деплоя приложения.
Наш сервер:
https://console.cloud.yandex.ru/folders/b1gsj0u15oahaf7t3cec/compute/instance/epdhctoei1vdkmeigvbc/overview
IP адрес статический 84.252.140.255
К нему уже привязан наш домен http://cheburland.ya-praktikum.tech/

В docker compose проброшен порт 80, чтобы приложение открывалось по адресу без указания порта.

Содержимое docker-compose файла из этого коммита копируется в настройки виртуальной машины (справа вверху кнопка "Изменить ВМ", далее поле из скрина ниже). В таком случае контейнеры будут стартовать автоматически при запуске сервера.

![image](https://github.com/27-mf-05/cheburland/assets/61501278/54c4dac8-e72e-4292-bcce-6445af0697e5)

В docker compose файле нужно обратить внимfние на строчку image в блоке server
  server:
    container_name: cheburland-server
    **image: dksr/cheburland:latest**

Это сбилженный и запушенный в docker hub образ последний с ветки development. Билдить и пушить образ в данный момент надо вручную.

Далее вместо образа в docker hub нужно здесь будет прописать ссылку на динамический образ CI/CD, который должен быть реализован в задаче с github actions.